### PR TITLE
accommodations for github issue #5

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,12 @@
 ##
 ## Change log for perl distribution PDL::VectorValued
 
+v1.0.19 Sat, 14 May 2022 11:52:08 +0200 moocow
+	* add vv_ prefix to all VectorValued::Utils functions
+	* add conditional aliases in VectorValued.pm BEGIN block for github issue #5
+	  - import %VV_IMPORT symbols from PDL core if available
+	  - export vv_FOO as PDL::FOO otherwise (compatibility)
+
 v1.0.18 Wed, 16 Mar 2022 20:23:23 +0100 moocow
 	* removed redundant mv(1,0)->...->mv(0,1) from setops trimming expressions
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,7 @@ WriteMakefile(
 			     "meta-spec" => { version => 2 },
 			     resources => {
 					   repository => {
-							  url => 'git://github.com/moocow-the-bovine/PDL-VectorValued.git',
+							  url => 'https://github.com/moocow-the-bovine/PDL-VectorValued.git',
 							  type => 'git',
 							  web => 'https://github.com/moocow-the-bovine/PDL-VectorValued',
 							 },

--- a/Utils/utils.pd
+++ b/Utils/utils.pd
@@ -5,7 +5,7 @@
 ##======================================================================
 
 #require "../VectorValued/Version.pm"; ##-- use perl-reversion from Perl::Version instead
-my $VERSION = '1.0.18';
+my $VERSION = '1.0.19';
 pp_setversion($VERSION);
 
 require "../VectorValued/Dev.pm";
@@ -76,7 +76,7 @@ EOPM
 
 ##------------------------------------------------------
 ## rlevec()
-pp_def('rlevec',
+pp_def('vv_rlevec',
        Pars => "c(M,N); $INDX \[o]a(N); [o]b(M,N)",
        Code =><<'EOC',
   PDL_Indx cn,bn=0, sn=$SIZE(N), matches;
@@ -126,10 +126,10 @@ EOD
 
 ##------------------------------------------------------
 ## rldvec()
-pp_def('rldvec',
+pp_def('vv_rldvec',
        Pars => 'int a(N); b(M,N); [o]c(M,N)',
        PMCode=><<'EOC',
-sub PDL::rldvec {
+sub PDL::vv_rldvec {
   my ($a,$b,$c) = @_;
   if (!defined($c)) {
 # XXX Need to improve emulation of threading in auto-generating c
@@ -139,7 +139,7 @@ sub PDL::rldvec {
     shift(@dims);
     $c = $b->zeroes($b->type,$rowlen,$size,@dims);
   }
-  &PDL::_rldvec_int($a,$b,$c);
+  &PDL::_vv_rldvec_int($a,$b,$c);
   return $c;
 }
 EOC
@@ -169,7 +169,7 @@ EOD
 
 ##------------------------------------------------------
 ## enumvec()
-pp_def('enumvec',
+pp_def('vv_enumvec',
        Pars => 'v(M,N); int [o]k(N)',
        Code =><<'EOC',
   int vn, kn, sn=$SIZE(N), matches;
@@ -202,7 +202,7 @@ EOD
 
 ##------------------------------------------------------
 ## enumvecg()
-pp_def('enumvecg',
+pp_def('vv_enumvecg',
        Pars => 'v(M,N); int [o]k(N)',
        Code =><<'EOC',
   int vn, vnprev, sn=$SIZE(N), ki;
@@ -236,7 +236,7 @@ EOD
 
 ##------------------------------------------------------
 ## rleseq()
-pp_def('rleseq',
+pp_def('vv_rleseq',
        Pars => "c(N); $INDX \[o]a(N); [o]b(N)",
        Code=><<'EOC',
   PDL_Indx j=0, sizeN=$SIZE(N);
@@ -275,10 +275,10 @@ EOD
 
 ##------------------------------------------------------
 ## rldseq()
-pp_def('rldseq',
+pp_def('vv_rldseq',
        Pars => 'int a(N); b(N); [o]c(M)',
        PMCode=><<'EOC',
-sub PDL::rldseq {
+sub PDL::vv_rldseq {
   my ($a,$b,$c) = @_;
   if (!defined($c)) {
     my $size   = $a->sumover->max;
@@ -286,7 +286,7 @@ sub PDL::rldseq {
     shift(@dims);
     $c = $b->zeroes($b->type,$size,@dims);
   }
-  &PDL::_rldseq_int($a,$b,$c);
+  &PDL::_vv_rldseq_int($a,$b,$c);
   return $c;
 }
 EOC
@@ -324,7 +324,7 @@ EOD
 ##------------------------------------------------------
 ## vsearchvec() : binary search on a (sorted) vector list
 vvpp_def
-  ('vsearchvec',
+  ('vv_vsearchvec',
    Pars => 'find(M); which(M,N); int [o]found();',
    Code =>
 (q(
@@ -368,7 +368,7 @@ Routine for searching N-dimensional values - akin to vsearch() for vectors.
 
 =for usage
 
- $found   = ccs_vsearchvec($find, $which);
+ $found   = vsearchvec($find, $which);
  $nearest = $which->dice_axis(1,$found);
 
 Returns for each row-vector in C<$find> the index along dimension N
@@ -408,7 +408,7 @@ EOPM
 ##------------------------------------------------------
 ## cmpvec() : make vector comparison available in perl
 vvpp_def
-  ('cmpvec',
+  ('vv_cmpvec',
    Pars => 'a(N); b(N); int [o]cmp()',
    Code => q($CMPVEC('$a()','$b()','N','$cmp()')),
    Doc=><<'EOD'

--- a/VectorValued.pm
+++ b/VectorValued.pm
@@ -140,13 +140,17 @@ New code should use C<FUNC()> or C<PDL::FUNC()>.
 
 =item *
 
-Backwards-compatible code can use C<FUNC()>, C<PDL::VectorValued::FUNC()>,
-or C<PDL::VectorValued::vv_FUNC()>.
+Backwards-compatible code can use C<FUNC()> or C<PDL::VectorValued::FUNC()>.
 
 =item *
 
-Direct use of C<PDL::VectorValued::Utils::FUNC()> and
-C<PDL::VectorValued::Utils::vv_FUNC()> is deprecated.
+Direct use of C<PDL::VectorValued::Utils::vv_FUNC()> is deprecated.
+
+=item *
+
+Direct use of C<PDL::VectorValued::Utils::FUNC()> is likely broken as of
+PDL::VectorValued v1.0.19.
+
 
 =back
 

--- a/VectorValued.pm
+++ b/VectorValued.pm
@@ -43,9 +43,9 @@ BEGIN {
 		   vv_union => {vv=>'vv_union', p=>PDL->can('unionvec')},
 		   vv_intersect => {vv=>'vv_intersect', p=>PDL->can('intersectvec')},
 		   vv_setdiff => {vv=>'vv_setdiff', p=>PDL->can('setdiffvec')},
-		   v_union => {vv=>'v_union', p=>PDL->can('sortedunion')},
-		   v_intersect => {vv=>'v_intersect', p=>PDL->can('sortedintersect')},
-		   v_setdiff => {vv=>'v_setdiff', p=>PDL->can('sortedsetdiff')},
+		   v_union => {vv=>'v_union', p=>PDL->can('union_sorted')},
+		   v_intersect => {vv=>'v_intersect', p=>PDL->can('intersect_sorted')},
+		   v_setdiff => {vv=>'v_setdiff', p=>PDL->can('setdiff_sorted')},
 		   vv_rleND => {vv=>'rleND', p=>undef},
 		   vv_rldND => {vv=>'rldND', p=>undef},
 		   #vv_indx => {vv=>'vv_indx', p=>PDL->can('indx')}, # DEBUG

--- a/VectorValued/Dev.pm
+++ b/VectorValued/Dev.pm
@@ -70,25 +70,6 @@ vector-valued PDLs.  It produces code for processing with PDL::PP.
 =cut
 
 
-##--------------------------------------------------------------
-## undef = vvpp_def($name,%args)
-=pod
-
-##======================================================================
-## Package Variables
-=pod
-
-=head1 Package Variables
-
-=head2 $VV_PREFIX
-
-Prefix appended
-
-=cut
-
-our $VVPP_PREFIX = "vvpp_";
-our $VV_PREFIX = "vv_";
-
 ##======================================================================
 ## PP Utiltiies
 =pod
@@ -462,7 +443,7 @@ and $imin if all values in $vals($imin:$imax-1) are strictly greater than $find.
 =item $options{cmpvar}
 
 If specified, temporary indices and comparison values will be stored in
-in the C variables $options{lovar}, $options{hivar}, $options{midvar}, and $options{cmpvar}.
+the C variables $options{lovar}, $options{hivar}, $options{midvar}, and $options{cmpvar}.
 If unspecified, new locally scoped C variables
 C<_vvpp_lb_loval> etc. will be declared and used.
 
@@ -562,9 +543,11 @@ All of these functions would be more intuitive if implemented directly
 as PDL::PP macros, and thus expanded directly by pp_def() rather
 than requiring vvpp_def().
 
-Unfortunately, I don't currently have the time to figure out how to
-use the (undocumented) PDL::PP macro expansion mechanism.
-Feel free to add real macro support.
+At the time of this module's writing, I was unable to figure out how to
+use the (then undocumented) PDL::PP macro expansion mechanism.
+As of 2022, PDL::PP offers support for user-defined macros, and
+this module should be refactored to take advantage of that... but that
+hasn't happened yet.
 
 =cut
 

--- a/VectorValued/Dev.pm
+++ b/VectorValued/Dev.pm
@@ -10,6 +10,8 @@
 
 package PDL::VectorValued::Dev;
 use PDL::Types;
+use PDL::Lite qw();  # for PDL::VERSION
+use version;
 use strict;
 
 ##======================================================================
@@ -17,7 +19,7 @@ use strict;
 #use PDL::PP; ##-- do NOT do this!
 use Exporter;
 
-our $VERSION = '1.0.18'; ##-- v1.0.4: use perl-reversion from Perl::Version instead
+our $VERSION = '1.0.19'; ##-- v1.0.4: use perl-reversion from Perl::Version instead
 our @ISA = qw(Exporter);
 our @EXPORT_OK =
   (
@@ -68,6 +70,26 @@ PDL::VectorValued::Dev provides some developer utilities for
 vector-valued PDLs.  It produces code for processing with PDL::PP.
 
 =cut
+
+
+##--------------------------------------------------------------
+## undef = vvpp_def($name,%args)
+=pod
+
+ ##======================================================================
+## Package Variables
+=pod
+
+=head1 Package Variables
+
+=head2 $VV_PREFIX
+
+Prefix appended
+
+=cut
+
+our $VVPP_PREFIX = "vvpp_";
+our $VV_PREFIX = "vv_";
 
 ##======================================================================
 ## PP Utiltiies

--- a/VectorValued/Dev.pm
+++ b/VectorValued/Dev.pm
@@ -10,8 +10,6 @@
 
 package PDL::VectorValued::Dev;
 use PDL::Types;
-use PDL::Lite qw();  # for PDL::VERSION
-use version;
 use strict;
 
 ##======================================================================
@@ -76,7 +74,7 @@ vector-valued PDLs.  It produces code for processing with PDL::PP.
 ## undef = vvpp_def($name,%args)
 =pod
 
- ##======================================================================
+##======================================================================
 ## Package Variables
 =pod
 

--- a/VectorValued/Version.pm
+++ b/VectorValued/Version.pm
@@ -7,7 +7,7 @@
 ##======================================================================
 
 package PDL::VectorValued::Version;
-our $VERSION = '1.0.18';
+our $VERSION = '1.0.19';
 #$PDL::VectorValued::VERSION = $VERSION;	##-- use perl-reversion from Perl::Version instead
 #$PDL::VectorValued::Dev::VERSION = $VERSION;	##-- use perl-reversion from Perl::Version instead
 


### PR DESCRIPTION
- add vv_ prefix to all VectorValued::Utils functions
- add conditional aliases in VectorValued.pm BEGIN block for github issue #5
  + import %VV_IMPORT symbols from PDL core if available
  + export vv_FOO as PDL::FOO otherwise (compatibility)
- bump to v1.0.19

@mohawk2 will this suffice to move forward on the PDL side of https://github.com/moocow-the-bovine/PDL-VectorValued/issues/5 ?