### PR TITLE
Dodge warnings under 2.080 which break Debian

### DIFF
--- a/VectorValued.pm
+++ b/VectorValued.pm
@@ -7,6 +7,7 @@
 
 package PDL::VectorValued;
 use strict;
+use warnings;
 
 ##======================================================================
 ## Export hacks
@@ -55,9 +56,9 @@ BEGIN {
   @EXPORT_OK = @VV_SYMBOLS;
   foreach my $vv_sym (@VV_SYMBOLS) {
     no strict 'refs';
-
     if ($VV_IMPORT{$vv_sym} && defined($VV_IMPORT{$vv_sym}{p})) {
       # function lives in PDL core: import it here, and clobber $vv_sym here (but not in VV::Utils)
+      no warnings 'redefine';
       *$vv_sym = *{$VV_IMPORT{$vv_sym}{vv}} = $VV_IMPORT{$vv_sym}{p};
     }
     elsif ($VV_IMPORT{$vv_sym}) {
@@ -250,8 +251,8 @@ See also: PDL::Slices::rle, PDL::Ngrams::VectorValued::Utils::vv_rlevec.
 
 =cut
 
-*PDL::vv_rleND = \&vv_rleND;
-sub rleND {
+*PDL::vv_rleND = \&vv_rleND if !defined &PDL::vv_rleND;
+*rleND = sub {
   my $data   = shift;
   my @vdimsN = $data->dims;
 
@@ -263,7 +264,7 @@ sub rleND {
   vv_rlevec($data->clump($#vdimsN), $counts, $elts->clump($#vdimsN));
 
   return ($counts,$elts);
-}
+} if !defined &rleND;
 
 ##----------------------------------------------------------------------
 ## rldND()
@@ -289,8 +290,8 @@ See also: PDL::Slices::rld, PDL::VectorValued::Utils::rldvec
 
 =cut
 
-*PDL::vv_rldND = \&vv_rldND;
-sub vv_rldND {
+*PDL::vv_rldND = \&vv_rldND if !defined &PDL::vv_rldND;
+*rldND = sub {
   my ($counts,$elts) = (shift,shift);
   my @vdimsN        = $elts->dims;
 
@@ -308,7 +309,7 @@ sub vv_rldND {
   vv_rldvec($counts, $elts->clump($#vdimsN), $data->clump($#vdimsN));
 
   return $data;
-}
+} if !defined &rldND;
 
 ##======================================================================
 ## pod: Functions: datatype utilities

--- a/t/01_rlevec.t
+++ b/t/01_rlevec.t
@@ -25,7 +25,7 @@ my ($tmp);
 ## 1..2: test rlevec()
 my $p = pdl([[1,2],[1,2],[1,2],[3,4],[3,4],[5,6]]);
 
-my ($pf,$pv)  = rlevec($p);
+my ($pf,$pv)  = vv_rlevec($p);
 my $pf_expect = pdl(long,[3,2,1,0,0,0]);
 my $pv_expect = pdl([[1,2],[3,4],[5,6],[0,0],[0,0],[0,0]]);
 
@@ -33,15 +33,15 @@ pdlok("rlevec():counts",  $pf, $pf_expect);
 pdlok("rlevec():elts",    $pv, $pv_expect);
 
 ## 3..3: test rldvec()
-my $pd = rldvec($pf,$pv);
+my $pd = vv_rldvec($pf,$pv);
 pdlok("rldvec()", $pd, $p);
 
 ## 4..4: test enumvec
-my $pk = enumvec($p);
+my $pk = vv_enumvec($p);
 pdlok("enumvec()", $pk, pdl(long,[0,1,2,0,1,0]));
 
 ## 5..5: test enumvecg
-$pk = enumvecg($p);
+$pk = vv_enumvecg($p);
 pdlok("enumvecg()", $pk, pdl(long,[0,0,0,1,1,2]));
 
 
@@ -49,12 +49,12 @@ pdlok("enumvecg()", $pk, pdl(long,[0,0,0,1,1,2]));
 ## rleND, rldND: 2d
 
 ## 6..7: test rleND(): 2d
-($pf,$pv) = rleND($p);
+($pf,$pv) = vv_rleND($p);
 pdlok("rleND():2d:counts", $pf, $pf_expect);
 pdlok("rleND():2d:elts",   $pv, $pv_expect);
 
 ## 8..8: test rldND(): 2d
-$pd = rldND($pf,$pv);
+$pd = vv_rldND($pf,$pv);
 pdlok("rldND():2d", $pd, $p);
 
 ##--------------------------------------------------------------
@@ -70,18 +70,18 @@ my $pv_expect_nd = zeroes($p_nd->type, $p_nd->dims);
 ($tmp=$pv_expect_nd->slice(",,0:3")) .= $p_nd->dice_axis(-1,[0,3,5,6]);
 
 ## 9..10: test rleND(): Nd
-my ($pf_nd,$pv_nd) = rleND($p_nd);
+my ($pf_nd,$pv_nd) = vv_rleND($p_nd);
 pdlok("rleND():Nd:counts", $pf_nd, $pf_expect_nd);
 pdlok("rleND():Nd:elts",   $pv_nd, $pv_expect_nd);
 
 ## 11..11: test rldND(): Nd
-my $pd_nd = rldND($pf_nd,$pv_nd);
+my $pd_nd = vv_rldND($pf_nd,$pv_nd);
 pdlok("rldND():Nd", $pd_nd, $p_nd);
 
 ##--------------------------------------------------------------
 ## 12..12: test enumvec(): nd
 my $v_nd = $p_nd->clump(2);
-my $k_nd = $v_nd->enumvec();
+my $k_nd = $v_nd->vv_enumvec();
 pdlok("enumvec():Nd", $k_nd, pdl(long,[0,1,2,0,1,0,0]));
 
 ##--------------------------------------------------------------
@@ -92,15 +92,14 @@ my $seqs = zeroes(short, 0);
 $seqs  = $seqs->append(sequence(short,$_)) foreach ($lens->list);
 $seqs += $lens->rld($offs);
 
-my $seqs_got = $lens->rldseq($offs);
+my $seqs_got = $lens->vv_rldseq($offs);
 isok("rldseq():type", $seqs_got->type, $seqs->type);
 pdlok("rldseq():data", $seqs_got, $seqs);
 
-my ($len_got,$off_got) = $seqs->rleseq();
+my ($len_got,$off_got) = $seqs->vv_rleseq();
 isok("rleseq():type", $off_got->type, $seqs->type);
 pdlok("rleseq():lens",  $len_got->where($len_got), $lens->where($lens));
 pdlok("rleseq():offs",  $off_got->where($len_got), $offs->where($lens));
 
 print "\n";
 # end of t/01_rlevec.t
-

--- a/t/02_cmpvec.t
+++ b/t/02_cmpvec.t
@@ -25,9 +25,9 @@ my $v1 = zeroes($vdim);
 my $v2 = pdl($v1);
 $v2->set(-1,1);
 
-isok("cmpvec:1d:<",  $v1->cmpvec($v2)<0);
-isok("cmpvec:1d:>",  $v2->cmpvec($v1)>0);
-isok("cmpvec:1d:==", $v1->cmpvec($v1)->sclr, 0);
+isok("cmpvec:1d:<",  $v1->vv_cmpvec($v2)<0);
+isok("cmpvec:1d:>",  $v2->vv_cmpvec($v1)>0);
+isok("cmpvec:1d:==", $v1->vv_cmpvec($v1)->sclr, 0);
 
 
 ##--------------------------------------------------------------
@@ -46,10 +46,9 @@ pdlok("vv_qsortveci", $p2d->dice_axis(1,$p2d->vv_qsortveci), $p2d->vv_qsortvec);
 my $which = pdl(long,[[0,0],[0,0],[0,1],[0,1],[1,0],[1,0],[1,1],[1,1]]);
 my $find  = $which->slice(",0:-1:2");
 
-pdlok("vsearchvec():match", $find->vsearchvec($which), pdl(long,[0,2,4,6]));
-isok("vsearchvev():<<",    all(pdl([-1,-1])->vsearchvec($which)==0));
-isok("vsearchvev():>>",    all(pdl([2,2])->vsearchvec($which)==$which->dim(1)-1));
+pdlok("vsearchvec():match", $find->vv_vsearchvec($which), pdl(long,[0,2,4,6]));
+isok("vsearchvev():<<",    all(pdl([-1,-1])->vv_vsearchvec($which)==0));
+isok("vsearchvev():>>",    all(pdl([2,2])->vv_vsearchvec($which)==$which->dim(1)-1));
 
 print "\n";
 # end of t/02_cmpvec.t
-

--- a/t/03_setops.t
+++ b/t/03_setops.t
@@ -288,5 +288,3 @@ test_v_thread_dimensions();
 print "\n";
 done_testing();
 # end of t/03_setops.t
-
-

--- a/t/04_types.t
+++ b/t/04_types.t
@@ -30,4 +30,3 @@ if (defined(&PDL::indx)) {
 
 print "\n";
 # end of t/04_types.t
-

--- a/t/05_vcos.t
+++ b/t/05_vcos.t
@@ -70,4 +70,3 @@ foreach my $badtest (@chkbad) {
 
 print "\n";
 # end of t/05_vcos.t
-


### PR DESCRIPTION
As shown by https://ci.debian.net/data/autopkgtest/testing/amd64/libp/libpdl-vectorvalued-perl/22201317/log.gz (text-search for "Fail") as linked from https://qa.debian.org/excuses.php?package=pdl, Debian is failing to build P:VV under PDL 2.080. This is because they run the installed module with `-w`, which triggers "redefined" warnings.

This PR successfully suppresses those warnings (and avoids being surprised by them in future by adding `use warnings`) under 2.080. You'll want to make sure to your own satisfaction this code doesn't break under older PDL.