### PR TITLE
thread -> broadcast in docs/comments - also, may I have `vcos` for Ufunc?

### DIFF
--- a/Utils/utils.pd
+++ b/Utils/utils.pd
@@ -132,7 +132,7 @@ pp_def('vv_rldvec',
 sub PDL::vv_rldvec {
   my ($a,$b,$c) = @_;
   if (!defined($c)) {
-# XXX Need to improve emulation of threading in auto-generating c
+# XXX Need to improve emulation of broadcasting in auto-generating c
     my ($rowlen) = $b->dim(0);
     my ($size) = $a->sumover->max;
     my (@dims) = $a->dims;
@@ -1010,7 +1010,7 @@ of a dense PDL $a().  This is basically the same thing as:
 the vector magnitudes.  Output values in $vcos() are cosine similarities in the range [-1,1],
 except for zero-magnitude vectors which will result in NaN values in $vcos().
 
-You can use PDL threading to batch-compute distances for multiple $b() vectors simultaneously:
+You can use PDL broadcasting to batch-compute distances for multiple $b() vectors simultaneously:
 
   $bx   = random($M, $NB);   ##-- get $NB random vectors of size $N
   $vcos = vv_vcos($a,$bx);   ##-- $vcos(i,j) ~ sim($a(,i),$b(,j))

--- a/t/03_setops.t
+++ b/t/03_setops.t
@@ -62,10 +62,10 @@ pdlok("v_intersect", scalar($a->v_intersect($b)),  $all->where($amask & $bmask))
 pdlok("v_setdiff", scalar($a->v_setdiff($b)), $all->where($amask & $bmask->not));
 
 ##--------------------------------------------------------------
-## vv_*: dim-checks and implicit thread dimensions
+## vv_*: dim-checks and implicit broadcast dimensions
 ##  + see https://github.com/moocow-the-bovine/PDL-VectorValued/issues/4
 
-sub test_vv_thread_dimensions {
+sub test_vv_broadcast_dimensions {
   ##-- vv_union
 
   my $empty = zeroes(3,0);
@@ -74,23 +74,23 @@ sub test_vv_thread_dimensions {
   my $xy = pdl([[4,5,6],[7,8,9]]);
 
   # vv_union: basic
-  pdlok("vv_union - thread dims - uw+wx", scalar($uw->vv_union($wx)), pdl([[-3,-2,-1],[1,2,3],[4,5,6]]));
-  pdlok("vv_union - thread dims - uw+xy", scalar($uw->vv_union($xy)), pdl([[-3,-2,-1],[1,2,3],[4,5,6],[7,8,9]]));
-  pdlok("vv_union - thread dims - 0+wx", scalar($empty->vv_union($wx)), $wx);
-  pdlok("vv_union - thread dims - wx+0", scalar($wx->vv_union($empty)), $wx);
-  pdlok("vv_union - thread dims - 0+0", scalar($empty->vv_union($empty)), $empty);
+  pdlok("vv_union - broadcast dims - uw+wx", scalar($uw->vv_union($wx)), pdl([[-3,-2,-1],[1,2,3],[4,5,6]]));
+  pdlok("vv_union - broadcast dims - uw+xy", scalar($uw->vv_union($xy)), pdl([[-3,-2,-1],[1,2,3],[4,5,6],[7,8,9]]));
+  pdlok("vv_union - broadcast dims - 0+wx", scalar($empty->vv_union($wx)), $wx);
+  pdlok("vv_union - broadcast dims - wx+0", scalar($wx->vv_union($empty)), $wx);
+  pdlok("vv_union - broadcast dims - 0+0", scalar($empty->vv_union($empty)), $empty);
 
-  # vv_union: threading/broadcasting
+  # vv_union: broadcasting
   my $k = 2;
   my $kempty = $empty->slice(",,*$k");
   my $kuw = $uw->slice(",,*$k");
   my $kwx = $wx->slice(",,*$k");
   my $kxy = $xy->slice(",,*$k");
-  pdlok("vv_union - thread dims - uw(*k)+wx", scalar($kuw->vv_union($wx)), pdl([[-3,-2,-1],[1,2,3],[4,5,6]])->slice(",,*$k"));
-  pdlok("vv_union - thread dims - uw(*k)+xy", scalar($kuw->vv_union($xy)), pdl([[-3,-2,-1],[1,2,3],[4,5,6],[7,8,9]])->slice(",,*$k"));
-  pdlok("vv_union - thread dims - 0(*k)+wx", scalar($kempty->vv_union($wx)), $kwx);
-  pdlok("vv_union - thread dims - wx(*k)+0", scalar($kwx->vv_union($empty)), $kwx);
-  pdlok("vv_union - thread dims - 0(*k)+0", scalar($kempty->vv_union($empty)), $kempty);
+  pdlok("vv_union - broadcast dims - uw(*k)+wx", scalar($kuw->vv_union($wx)), pdl([[-3,-2,-1],[1,2,3],[4,5,6]])->slice(",,*$k"));
+  pdlok("vv_union - broadcast dims - uw(*k)+xy", scalar($kuw->vv_union($xy)), pdl([[-3,-2,-1],[1,2,3],[4,5,6],[7,8,9]])->slice(",,*$k"));
+  pdlok("vv_union - broadcast dims - 0(*k)+wx", scalar($kempty->vv_union($wx)), $kwx);
+  pdlok("vv_union - broadcast dims - wx(*k)+0", scalar($kwx->vv_union($empty)), $kwx);
+  pdlok("vv_union - broadcast dims - 0(*k)+0", scalar($kempty->vv_union($empty)), $kempty);
 
 
   ##-- vv_intersect
@@ -101,46 +101,46 @@ sub test_vv_thread_dimensions {
   my $haystack = pdl([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]);
 
   # vv_intersect: basic
-  pdlok("vv_intersect - thread dims - needle0&haystack", scalar($needle0->vv_intersect($haystack)), $empty);
-  pdlok("vv_intersect - thread dims - needle1&haystack", scalar($needle1->vv_intersect($haystack)), $needle1);
-  pdlok("vv_intersect - thread dims - needles&haystack", scalar($needles->vv_intersect($haystack)), $needle1);
-  pdlok("vv_intersect - thread dims - haystack&haystack", scalar($haystack->vv_intersect($haystack)), $haystack);
-  pdlok("vv_intersect - thread dims - haystack&empty", scalar($haystack->vv_intersect($empty)), $empty);
-  pdlok("vv_intersect - thread dims - empty&haystack", scalar($empty->vv_intersect($haystack)), $empty);
+  pdlok("vv_intersect - broadcast dims - needle0&haystack", scalar($needle0->vv_intersect($haystack)), $empty);
+  pdlok("vv_intersect - broadcast dims - needle1&haystack", scalar($needle1->vv_intersect($haystack)), $needle1);
+  pdlok("vv_intersect - broadcast dims - needles&haystack", scalar($needles->vv_intersect($haystack)), $needle1);
+  pdlok("vv_intersect - broadcast dims - haystack&haystack", scalar($haystack->vv_intersect($haystack)), $haystack);
+  pdlok("vv_intersect - broadcast dims - haystack&empty", scalar($haystack->vv_intersect($empty)), $empty);
+  pdlok("vv_intersect - broadcast dims - empty&haystack", scalar($empty->vv_intersect($haystack)), $empty);
 
-  # vv_intersect: threading/broadcasting
+  # vv_intersect: broadcasting
   my $kneedle0 = $needle0->slice(",,*$k");
   my $kneedle1 = $needle1->slice(",,*$k");
   my $kneedles = pdl([[[-3,-2,-1]],[[1,2,3]]]);
   my $khaystack = $haystack->slice(",,*$k");
-  pdlok("vv_intersect - thread dims - needle0(*k)&haystack", scalar($kneedle0->vv_intersect($haystack)), $kempty);
-  pdlok("vv_intersect - thread dims - needle1(*k)&haystack", scalar($kneedle1->vv_intersect($haystack)), $kneedle1);
-  pdlok("vv_intersect - thread dims - needles(*k)&haystack",
+  pdlok("vv_intersect - broadcast dims - needle0(*k)&haystack", scalar($kneedle0->vv_intersect($haystack)), $kempty);
+  pdlok("vv_intersect - broadcast dims - needle1(*k)&haystack", scalar($kneedle1->vv_intersect($haystack)), $kneedle1);
+  pdlok("vv_intersect - broadcast dims - needles(*k)&haystack",
 	scalar($kneedles->vv_intersect($haystack)),
 	pdl([[[0,0,0]],[[1,2,3]]]));
-  pdlok("vv_intersect - thread dims - haystack(*k)&haystack", scalar($khaystack->vv_intersect($haystack)), $khaystack);
-  pdlok("vv_intersect - thread dims - haystack(*k)&empty", scalar($khaystack->vv_intersect($empty)), $kempty);
-  pdlok("vv_intersect - thread dims - empty(*k)&haystack", scalar($kempty->vv_intersect($haystack)), $kempty);
+  pdlok("vv_intersect - broadcast dims - haystack(*k)&haystack", scalar($khaystack->vv_intersect($haystack)), $khaystack);
+  pdlok("vv_intersect - broadcast dims - haystack(*k)&empty", scalar($khaystack->vv_intersect($empty)), $kempty);
+  pdlok("vv_intersect - broadcast dims - empty(*k)&haystack", scalar($kempty->vv_intersect($haystack)), $kempty);
 
   ##-- vv_setdiff
 
   # vv_setdiff: basic
-  pdlok("vv_setdiff - thread dims - haystack-needle0", scalar($haystack->vv_setdiff($needle0)), $haystack);
-  pdlok("vv_setdiff - thread dims - haystack-needle1", scalar($haystack->vv_setdiff($needle1)), $haystack->slice(",1:-1"));
-  pdlok("vv_setdiff - thread dims - haystack-needles", scalar($haystack->vv_setdiff($needles)), $haystack->slice(",1:-1"));
-  pdlok("vv_setdiff - thread dims - haystack-haystack", scalar($haystack->vv_setdiff($haystack)), $empty);
-  pdlok("vv_setdiff - thread dims - haystack-empty", scalar($haystack->vv_setdiff($empty)), $haystack);
-  pdlok("vv_setdiff - thread dims - empty-haystack", scalar($empty->vv_setdiff($haystack)), $empty);
+  pdlok("vv_setdiff - broadcast dims - haystack-needle0", scalar($haystack->vv_setdiff($needle0)), $haystack);
+  pdlok("vv_setdiff - broadcast dims - haystack-needle1", scalar($haystack->vv_setdiff($needle1)), $haystack->slice(",1:-1"));
+  pdlok("vv_setdiff - broadcast dims - haystack-needles", scalar($haystack->vv_setdiff($needles)), $haystack->slice(",1:-1"));
+  pdlok("vv_setdiff - broadcast dims - haystack-haystack", scalar($haystack->vv_setdiff($haystack)), $empty);
+  pdlok("vv_setdiff - broadcast dims - haystack-empty", scalar($haystack->vv_setdiff($empty)), $haystack);
+  pdlok("vv_setdiff - broadcast dims - empty-haystack", scalar($empty->vv_setdiff($haystack)), $empty);
 
-  # vv_setdiff: threading/broadcasting
-  pdlok("vv_setdiff - thread dims - haystack(*k)-needle0", scalar($khaystack->vv_setdiff($needle0)), $khaystack);
-  pdlok("vv_setdiff - thread dims - haystack(*k)-needle1", scalar($khaystack->vv_setdiff($needle1)), $khaystack->slice(",1:-1,"));
-  pdlok("vv_setdiff - thread dims - haystack(*k)-needles", scalar($khaystack->vv_setdiff($needles)), $khaystack->slice(",1:-1,"));
-  pdlok("vv_setdiff - thread dims - haystack(*k)-haystack", scalar($khaystack->vv_setdiff($haystack)), $kempty);
-  pdlok("vv_setdiff - thread dims - haystack(*k)-empty", scalar($khaystack->vv_setdiff($empty)), $khaystack);
-  pdlok("vv_setdiff - thread dims - empty(*k)-haystack", scalar($kempty->vv_setdiff($haystack)), $kempty);
+  # vv_setdiff: broadcasting
+  pdlok("vv_setdiff - broadcast dims - haystack(*k)-needle0", scalar($khaystack->vv_setdiff($needle0)), $khaystack);
+  pdlok("vv_setdiff - broadcast dims - haystack(*k)-needle1", scalar($khaystack->vv_setdiff($needle1)), $khaystack->slice(",1:-1,"));
+  pdlok("vv_setdiff - broadcast dims - haystack(*k)-needles", scalar($khaystack->vv_setdiff($needles)), $khaystack->slice(",1:-1,"));
+  pdlok("vv_setdiff - broadcast dims - haystack(*k)-haystack", scalar($khaystack->vv_setdiff($haystack)), $kempty);
+  pdlok("vv_setdiff - broadcast dims - haystack(*k)-empty", scalar($khaystack->vv_setdiff($empty)), $khaystack);
+  pdlok("vv_setdiff - broadcast dims - empty(*k)-haystack", scalar($kempty->vv_setdiff($haystack)), $kempty);
 }
-test_vv_thread_dimensions();
+test_vv_broadcast_dimensions();
 
 ##--------------------------------------------------------------
 ## vv_intersect tests as suggested by ETJ/mowhawk2
@@ -224,17 +224,17 @@ sub test_vv_intersect_implicit_dims {
 test_vv_intersect_implicit_dims();
 
 ##--------------------------------------------------------------
-## v_*: dim-checks and implicit thread dimensions
+## v_*: dim-checks and implicit broadcast dimensions
 ##  + analogous to https://github.com/moocow-the-bovine/PDL-VectorValued/issues/4
 
-sub test_v_thread_dimensions {
+sub test_v_broadcast_dimensions {
   # data: basic
   my $empty = zeroes(0);
   my $v1_2 = pdl([1,2]);
   my $v3_4 = pdl([3,4]);
   my $v1_4 = $v1_2->cat($v3_4)->flat;
 
-  # data: threading/broadcasting
+  # data: broadcasting
   my $k = 2;
   my $kempty = $empty->slice(",*$k");
   my $kv1_2 = $v1_2->slice(",*$k");
@@ -242,46 +242,46 @@ sub test_v_thread_dimensions {
   my $kv1_4 = $v1_4->slice(",*$k");
 
   #-- v_union
-  pdlok("v_union - thread dims - 12+34", scalar($v1_2->v_union($v3_4)), $v1_4);
-  pdlok("v_union - thread dims - 34+1234", scalar($v3_4->v_union($v1_4)), $v1_4);
-  pdlok("v_union - thread dims - 0+1234", scalar($empty->v_union($v1_4)), $v1_4);
-  pdlok("v_union - thread dims - 1234+0", scalar($v1_4->v_union($empty)), $v1_4);
-  pdlok("v_union - thread dims - 0+0", scalar($empty->v_union($empty)), $empty);
+  pdlok("v_union - broadcast dims - 12+34", scalar($v1_2->v_union($v3_4)), $v1_4);
+  pdlok("v_union - broadcast dims - 34+1234", scalar($v3_4->v_union($v1_4)), $v1_4);
+  pdlok("v_union - broadcast dims - 0+1234", scalar($empty->v_union($v1_4)), $v1_4);
+  pdlok("v_union - broadcast dims - 1234+0", scalar($v1_4->v_union($empty)), $v1_4);
+  pdlok("v_union - broadcast dims - 0+0", scalar($empty->v_union($empty)), $empty);
   #
-  pdlok("v_union - thread dims - 12(*k)+34", scalar($kv1_2->v_union($v3_4)), $kv1_4);
-  pdlok("v_union - thread dims - 34(*k)+1234", scalar($kv3_4->v_union($v1_4)), $kv1_4);
-  pdlok("v_union - thread dims - 0(*k)+1234", scalar($kempty->v_union($v1_4)), $kv1_4);
-  pdlok("v_union - thread dims - 1234(*k)+0", scalar($kv1_4->v_union($empty)), $kv1_4);
-  pdlok("v_union - thread dims - 0(*k)+0", scalar($kempty->v_union($empty)), $kempty);
+  pdlok("v_union - broadcast dims - 12(*k)+34", scalar($kv1_2->v_union($v3_4)), $kv1_4);
+  pdlok("v_union - broadcast dims - 34(*k)+1234", scalar($kv3_4->v_union($v1_4)), $kv1_4);
+  pdlok("v_union - broadcast dims - 0(*k)+1234", scalar($kempty->v_union($v1_4)), $kv1_4);
+  pdlok("v_union - broadcast dims - 1234(*k)+0", scalar($kv1_4->v_union($empty)), $kv1_4);
+  pdlok("v_union - broadcast dims - 0(*k)+0", scalar($kempty->v_union($empty)), $kempty);
 
   #-- v_intersect
-  pdlok("v_intersect - thread dims - 12&34", scalar($v1_2->v_intersect($v3_4)), $empty);
-  pdlok("v_intersect - thread dims - 34&1234", scalar($v3_4->v_intersect($v1_4)), $v3_4);
-  pdlok("v_intersect - thread dims - 0&1234", scalar($empty->v_intersect($v1_4)), $empty);
-  pdlok("v_intersect - thread dims - 1234&0", scalar($v1_4->v_intersect($empty)), $empty);
-  pdlok("v_intersect - thread dims - 0&0", scalar($empty->v_intersect($empty)), $empty);
+  pdlok("v_intersect - broadcast dims - 12&34", scalar($v1_2->v_intersect($v3_4)), $empty);
+  pdlok("v_intersect - broadcast dims - 34&1234", scalar($v3_4->v_intersect($v1_4)), $v3_4);
+  pdlok("v_intersect - broadcast dims - 0&1234", scalar($empty->v_intersect($v1_4)), $empty);
+  pdlok("v_intersect - broadcast dims - 1234&0", scalar($v1_4->v_intersect($empty)), $empty);
+  pdlok("v_intersect - broadcast dims - 0&0", scalar($empty->v_intersect($empty)), $empty);
   #
-  pdlok("v_intersect - thread dims - 12(*k)&34", scalar($kv1_2->v_intersect($v3_4)), $kempty);
-  pdlok("v_intersect - thread dims - 34(*k)&1234", scalar($kv3_4->v_intersect($v1_4)), $kv3_4);
-  pdlok("v_intersect - thread dims - 0(*k)&1234", scalar($kempty->v_intersect($v1_4)), $kempty);
-  pdlok("v_intersect - thread dims - 1234(*k)&0", scalar($kv1_4->v_intersect($empty)), $kempty);
-  pdlok("v_intersect - thread dims - 0(*k)&0", scalar($kempty->v_intersect($empty)), $kempty);
+  pdlok("v_intersect - broadcast dims - 12(*k)&34", scalar($kv1_2->v_intersect($v3_4)), $kempty);
+  pdlok("v_intersect - broadcast dims - 34(*k)&1234", scalar($kv3_4->v_intersect($v1_4)), $kv3_4);
+  pdlok("v_intersect - broadcast dims - 0(*k)&1234", scalar($kempty->v_intersect($v1_4)), $kempty);
+  pdlok("v_intersect - broadcast dims - 1234(*k)&0", scalar($kv1_4->v_intersect($empty)), $kempty);
+  pdlok("v_intersect - broadcast dims - 0(*k)&0", scalar($kempty->v_intersect($empty)), $kempty);
 
   #-- v_setdiff
-  pdlok("v_setdiff - thread dims - 12-34", scalar($v1_2->v_setdiff($v3_4)), $v1_2);
-  pdlok("v_setdiff - thread dims - 34-1234", scalar($v3_4->v_setdiff($v1_4)), $empty);
-  pdlok("v_setdiff - thread dims - 1234-0", scalar($v1_4->v_setdiff($empty)), $v1_4);
-  pdlok("v_setdiff - thread dims - 0-1234", scalar($empty->v_setdiff($v1_4)), $empty);
-  pdlok("v_setdiff - thread dims - 0-0", scalar($empty->v_setdiff($empty)), $empty);
+  pdlok("v_setdiff - broadcast dims - 12-34", scalar($v1_2->v_setdiff($v3_4)), $v1_2);
+  pdlok("v_setdiff - broadcast dims - 34-1234", scalar($v3_4->v_setdiff($v1_4)), $empty);
+  pdlok("v_setdiff - broadcast dims - 1234-0", scalar($v1_4->v_setdiff($empty)), $v1_4);
+  pdlok("v_setdiff - broadcast dims - 0-1234", scalar($empty->v_setdiff($v1_4)), $empty);
+  pdlok("v_setdiff - broadcast dims - 0-0", scalar($empty->v_setdiff($empty)), $empty);
   #
-  pdlok("v_setdiff - thread dims - 12(*k)-34", scalar($kv1_2->v_setdiff($v3_4)), $kv1_2);
-  pdlok("v_setdiff - thread dims - 34(*k)-1234", scalar($kv3_4->v_setdiff($v1_4)), $kempty);
-  pdlok("v_setdiff - thread dims - 1234(*k)-0", scalar($kv1_4->v_setdiff($empty)), $kv1_4);
-  pdlok("v_setdiff - thread dims - 0(*k)-1234", scalar($kempty->v_setdiff($v1_4)), $kempty);
-  pdlok("v_setdiff - thread dims - 0(*k)-0", scalar($kempty->v_setdiff($empty)), $kempty);
+  pdlok("v_setdiff - broadcast dims - 12(*k)-34", scalar($kv1_2->v_setdiff($v3_4)), $kv1_2);
+  pdlok("v_setdiff - broadcast dims - 34(*k)-1234", scalar($kv3_4->v_setdiff($v1_4)), $kempty);
+  pdlok("v_setdiff - broadcast dims - 1234(*k)-0", scalar($kv1_4->v_setdiff($empty)), $kv1_4);
+  pdlok("v_setdiff - broadcast dims - 0(*k)-1234", scalar($kempty->v_setdiff($v1_4)), $kempty);
+  pdlok("v_setdiff - broadcast dims - 0(*k)-0", scalar($kempty->v_setdiff($empty)), $kempty);
 
 }
-test_v_thread_dimensions();
+test_v_broadcast_dimensions();
 
 
 

--- a/t/05_vcos.t
+++ b/t/05_vcos.t
@@ -30,7 +30,7 @@ my $c_want = pdl([1,0.8660254,-1]);
 
 ##-- 1..2: vcos: basic
 pdlapprox("vv_vcos:flat", $a->vv_vcos($b), $c_want, 1e-4);
-pdlapprox("vv_vcos:threaded", $a->vv_vcos($b->slice(",*3")), $c_want->slice(",*3"), 1e-4);
+pdlapprox("vv_vcos:broadcasted", $a->vv_vcos($b->slice(",*3")), $c_want->slice(",*3"), 1e-4);
 
 ##-- 3: vcos: nullvec: a
 my $a0 = $a->pdl;

--- a/testme.perl
+++ b/testme.perl
@@ -328,7 +328,7 @@ sub test_vsetops_dimcheck {
   my $v3_4 = pdl([3,4]);
   my $v1_4 = $v1_2->cat($v3_4)->flat;
 
-  # data: threaded
+  # data: broadcasted
   my $k = 2;
   my $kempty = $empty->slice(",*$k");
   my $kv1_2 = $v1_2->slice(",*$k");

--- a/utils.pod
+++ b/utils.pod
@@ -433,7 +433,7 @@ of a dense PDL $a().  This is basically the same thing as:
 the vector magnitudes.  Output values in $vcos() are cosine similarities in the range [-1,1],
 except for zero-magnitude vectors which will result in NaN values in $vcos().
 
-You can use PDL threading to batch-compute distances for multiple $b() vectors simultaneously:
+You can use PDL broadcasting to batch-compute distances for multiple $b() vectors simultaneously:
 
   $bx   = random($M, $NB);   ##-- get $NB random vectors of size $N
   $vcos = vv_vcos($a,$bx);   ##-- $vcos(i,j) ~ sim($a(,i),$b(,j))


### PR DESCRIPTION
This is entirely aesthetic, and I left `threadloop` untouched since your actual minimum PDL here is still 2.019. Is that something you're still fixed on?

Also, and not really connected to this: would you mind my incorporating `vcos` into Ufunc? I'm porting Math::3Space to PDL (https://github.com/nrdvana/perl-Math-3Space/issues/2) and it would enable some code-deleting and make things a tad quicker. I'm also going to make a `magnitude`/`magover` pair, since bizarrely that's missing. I may well also make `project` etc to make that port be fairly trivial, which it isn't yet.